### PR TITLE
feat(os): add compatibility for Windows OS

### DIFF
--- a/.changeset/serious-elephants-stare.md
+++ b/.changeset/serious-elephants-stare.md
@@ -1,0 +1,5 @@
+---
+"@infinit-xyz/cli": patch
+---
+
+Add compatibility for Windows OS

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # @infinit-xyz/cli
 
-![Statements](https://img.shields.io/badge/statements-52.2%25-red.svg?style=flat)
-![Branches](https://img.shields.io/badge/branches-35.83%25-red.svg?style=flat)
+![Statements](https://img.shields.io/badge/statements-52.25%25-red.svg?style=flat)
+![Branches](https://img.shields.io/badge/branches-35.91%25-red.svg?style=flat)
 ![Functions](https://img.shields.io/badge/functions-55.05%25-red.svg?style=flat)
-![Lines](https://img.shields.io/badge/lines-52.18%25-red.svg?style=flat)
+![Lines](https://img.shields.io/badge/lines-52.23%25-red.svg?style=flat)
 
 
 To install dependencies:

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,4 +1,5 @@
 import { $ } from 'bun'
+import os from 'os'
 
 try {
   const externalPackages = [
@@ -71,7 +72,13 @@ try {
   // Generate dist folders to store assets
   await $`rm -rf dist`
   await $`mkdir dist`
-  await $`cp -r src/schemas dist/schemas`
+
+  if (os.platform() === 'win32') {
+    await $`xcopy src\\schemas dist\\schemas /E /I /Y`
+  } else {
+    await $`cp -r src/schemas dist/schemas`
+  }
+
   console.log('✅ Generated dist')
 } catch (error) {
   console.error('❌ Error in scripts/build.ts')

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,5 +1,5 @@
 import { $ } from 'bun'
-import os from 'os'
+import os from 'node:os'
 
 try {
   const externalPackages = [

--- a/src/utils/childprocess.ts
+++ b/src/utils/childprocess.ts
@@ -1,8 +1,11 @@
 import { spawn } from 'node:child_process'
+import os from 'node:os'
 
 export const spawnChild = (cmd: string, args: string[], env?: NodeJS.ProcessEnv) => {
+  const isWindowsOs = os.platform() === 'win32'
+
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: 'pipe', env: { ...process.env, ...env } })
+    const child = spawn(cmd, args, { stdio: 'pipe', env: { ...process.env, ...env }, ...(isWindowsOs ? { shell: true } : {}) })
     child.on('close', (code) => {
       if (code !== 0) {
         reject({


### PR DESCRIPTION
Add compatibility for Windows OS
- Check for Windows OS for some specific build command
- Add `{shell: true}` for `spawnChild`